### PR TITLE
Option to hide zeroes for hour/minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ Colors: Black, Red, Green, Yellow, Blue, Purple, Cyan, White
 
 -k  Allow countdown to go negative / Stopwatch mode
 
+-0 Hide hour or minutes when zero
+
 --help  shows this help

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,7 @@ fn events(tx: Tx) {
     thread::spawn(move || loop {
         if let Ok(ev) = event::read() {
             match ev {
-                event::Event::Key(event::KeyEvent {
-                    code: event::KeyCode::Esc,
-                    ..
-                }) => {
+                event::Event::Key(event::KeyEvent { code: event::KeyCode::Esc, .. }) => {
                     let _ = tx.send(Event::Quit);
                 }
                 event::Event::Key(event::KeyEvent {
@@ -57,10 +54,10 @@ fn format_time(mut total_sec: i128) -> String {
     let seconds = total_sec - minutes * 60 - hours * 60 * 60;
 
     format!(
-        "{}{:0>2}:{:0>2}:{:0>2}",
+        "{}{}{}{:0>2}",
         if is_less_than_zero { "-" } else { "" },
-        hours,
-        minutes,
+        if hours.eq(&0) { "".to_string() } else { format!("{:0>2}:", hours) },
+        if hours.eq(&0) && minutes.eq(&0) { "".to_string() } else { format!("{:0>2}:", minutes) },
         seconds
     )
 }
@@ -183,11 +180,7 @@ fn parse_args(args: Vec<String>) -> Option<AfkConfig> {
     }
 
     // prefer some time to act against, unless allow_negative, which is basically just a stopwatch
-    if config.hours.eq(&0)
-        && config.minutes.eq(&0)
-        && config.seconds.eq(&0)
-        && !config.allow_negative
-    {
+    if config.hours.eq(&0) && config.minutes.eq(&0) && config.seconds.eq(&0) && !config.allow_negative {
         show_error(&format!("Please specifiy some time or -k for stopwatch."));
         return None;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ fn events(tx: Tx) {
     thread::spawn(move || loop {
         if let Ok(ev) = event::read() {
             match ev {
-                event::Event::Key(event::KeyEvent { code: event::KeyCode::Esc, .. }) => {
+                event::Event::Key(event::KeyEvent {
+                    code: event::KeyCode::Esc,
+                    ..
+                }) => {
                     let _ = tx.send(Event::Quit);
                 }
                 event::Event::Key(event::KeyEvent {
@@ -56,8 +59,16 @@ fn format_time(mut total_sec: i128, show_zeroes: bool) -> String {
     format!(
         "{}{}{}{:0>2}",
         if is_less_than_zero { "-" } else { "" },
-        if hours.eq(&0) && !show_zeroes { "".to_string() } else { format!("{:0>2}:", hours) },
-        if hours.eq(&0) && minutes.eq(&0) && !show_zeroes { "".to_string() } else { format!("{:0>2}:", minutes) },
+        if hours.eq(&0) && !show_zeroes {
+            "".to_string()
+        } else {
+            format!("{:0>2}:", hours)
+        },
+        if hours.eq(&0) && minutes.eq(&0) && !show_zeroes {
+            "".to_string()
+        } else {
+            format!("{:0>2}:", minutes)
+        },
         seconds
     )
 }
@@ -187,7 +198,11 @@ fn parse_args(args: Vec<String>) -> Option<AfkConfig> {
     }
 
     // prefer some time to act against, unless allow_negative, which is basically just a stopwatch
-    if config.hours.eq(&0) && config.minutes.eq(&0) && config.seconds.eq(&0) && !config.allow_negative {
+    if config.hours.eq(&0)
+        && config.minutes.eq(&0)
+        && config.seconds.eq(&0)
+        && !config.allow_negative
+    {
         show_error(&format!("Please specifiy some time or -k for stopwatch."));
         return None;
     }


### PR DESCRIPTION
The command line option -0 will allow you to hide the hour or minute fields when they are 0.

Normal use will show timer as: HH:MM::SS
With -0 it will show as: 01:30 for 1 minute 30 second or 01:00:30 for 1 hour 30 seconds.