### PR TITLE
Configurable padding for message and timer; Option to center timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,19 @@ Color can be a comma or quoted space separated RGB value: 42,42,42 or "42 42 42"
 -c color  colors the text with a bold foreground color.
 Colors: Black, Red, Green, Yellow, Blue, Purple, Cyan, White
 
--k  Allow countdown to go negative / Stopwatch mode
+-k Allow countdown to go negative / Stopwatch mode
 
 -0 Hide hour or minutes when zero
 
 -f Use figgle font for message
+
+-z Horizontally centers the timer
+
+-p # Same message padding for top and bottom
+-p # # Different message padding for top and bottom
+
+-t # Same timer padding for top and bottom
+-t # # Different timer padding for top and bottom
+Horizontal padding will only be applied when timer is not centered
 
 --help  shows this help

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn parse_args(args: &[String]) -> Option<AfkConfig> {
                         "-s" => config.seconds = t,
                         _ => {}
                     },
-                    Err(_) => show_error!(&format!("Cannout parse number after {}.", arg)),
+                    Err(_) => show_error!(&format!("Cannot parse number after {}.", arg)),
                 },
                 None => show_error!(&format!("Missing number after {}.", arg)),
             },
@@ -160,12 +160,12 @@ fn parse_args(args: &[String]) -> Option<AfkConfig> {
                 config.message_padding = match (args.next(), args.peek()) {
                     (Some(x), Some(y)) if !y.starts_with('-') => match (x.parse(), y.parse()) {
                         (Ok(x), Ok(y)) => (x, y),
-                        (Err(_), _) => show_error!(&format!("Cannout parse number {x} after {arg}.")),
-                        (_, _) => show_error!(&format!("Cannout parse number {y} after {arg}.")),
+                        (Err(_), _) => show_error!(&format!("Cannot parse number {x} after {arg}.")),
+                        (_, _) => show_error!(&format!("Cannot parse number {y} after {arg}.")),
                     },
                     (Some(p), _) => match p.parse() {
                         Ok(p) => (p, p),
-                        Err(_) => show_error!(&format!("Cannout parse number {p} after {arg}.")),
+                        Err(_) => show_error!(&format!("Cannot parse number {p} after {arg}.")),
                     },
                     _ => show_error!(&format!("Missing padding after {arg}.")),
                 }
@@ -174,8 +174,8 @@ fn parse_args(args: &[String]) -> Option<AfkConfig> {
                 config.timer_padding = match (args.next(), args.peek()) {
                     (Some(x), Some(y)) if !y.starts_with('-') => match (x.parse(), y.parse()) {
                         (Ok(x), Ok(y)) => (x, y),
-                        (Err(_), _) => show_error!(&format!("Cannout parse number {x} after {arg}.")),
-                        (_, _) => show_error!(&format!("Cannout parse number {y} after {arg}.")),
+                        (Err(_), _) => show_error!(&format!("Cannot parse number {x} after {arg}.")),
+                        (_, _) => show_error!(&format!("Cannot parse number {y} after {arg}.")),
                     },
                     (Some(p), _) => match p.parse() {
                         Ok(p) => (p, p),


### PR DESCRIPTION
I set the padding values to match the old afk-timer behavior if you want the default to be 0, I'll change that.
